### PR TITLE
fix: make fillMissingData request specific routes when asking npm metadata

### DIFF
--- a/analysisrequest/npm.go
+++ b/analysisrequest/npm.go
@@ -144,61 +144,34 @@ func (arn *NPM) fillMissingData(parent context.Context, registryClient npm.Regis
 	defer span.End()
 
 	if len(arn.Version) == 0 {
-		packageList, err := registryClient.GetPackageList(ctx, arn.Name)
+		pv, err := registryClient.GetPackageLatestVersion(ctx, arn.Name)
 		if err != nil {
 			return err
 		}
-		if packageList == nil {
-			return ErrMalfunctioningNPMRegistryClient
-		}
-		latestVersionTag := packageList.DistTags.Latest
-		if len(latestVersionTag) == 0 {
-			return ErrCouldNotRetrieveLastVersionTagFromNPM
-		}
-		if latestVersion, ok := packageList.Versions[latestVersionTag]; ok {
-			arn.Version = latestVersion.Version
-			arn.Shasum = latestVersion.Dist.Shasum
-		}
-		if len(arn.Version) == 0 {
-			return ErrCouldNotRetrieveLastVersionFromNPM
-		}
-		if len(arn.Shasum) == 0 {
-			return ErrCouldNotRetrieveLastShasumFromNPM
-		}
-
+		arn.Version = pv.Version
+		arn.Shasum = pv.Dist.Shasum
 		return nil
 	}
 
 	if len(arn.Version) > 0 && len(arn.Shasum) == 0 {
-		packageList, err := registryClient.GetPackageList(ctx, arn.Name)
+		pv, err := registryClient.GetPackageVersion(ctx, arn.Name, arn.Version)
 		if err != nil {
 			return err
 		}
-		if packageList == nil {
-			return ErrMalfunctioningNPMRegistryClient
-		}
-		if version, ok := packageList.Versions[arn.Version]; ok {
-			arn.Version = version.Version
-			arn.Shasum = version.Dist.Shasum
-		} else {
-			return ErrGivenVersionNotFoundOnNPM
-		}
-		if len(arn.Shasum) == 0 {
-			return ErrCouldNotRetrieveShasumForGivenVersionFromNPM
-		}
-
+		arn.Version = pv.Version
+		arn.Shasum = pv.Dist.Shasum
 		return nil
 	}
 
 	if len(arn.Version) > 0 && len(arn.Shasum) > 0 {
-		packageVersion, err := registryClient.GetPackageVersion(ctx, arn.Name, arn.Version)
+		pv, err := registryClient.GetPackageVersion(ctx, arn.Name, arn.Version)
 		if err != nil {
 			return ErrGivenVersionNotFoundOnNPM
 		}
-		if packageVersion == nil {
+		if pv == nil {
 			return ErrMalfunctioningNPMRegistryClient
 		}
-		if packageVersion.Dist.Shasum != arn.Shasum {
+		if pv.Dist.Shasum != arn.Shasum {
 			return ErrGivenShasumDoesntMatchGivenVersionOnNPM
 		}
 	}


### PR DESCRIPTION
There are certain npm packages, (e.g:
https://registry.npmjs.org/@typescript-eslint/eslint-plugin) that are extremely heavy in terms of number of versions and metadata in general.

NPM.fillMissingData was asking for the full list when called causing issues to the caller when the timeout is reached.

This fix makes fillMissingData call the specific routes for what it needs so we remove the number of versions from the equation.