### PR TITLE
fix: make fillMissingData request specific routes when asking npm metadata

### DIFF
--- a/analysisrequest/builder_test.go
+++ b/analysisrequest/builder_test.go
@@ -72,6 +72,19 @@ func (r *mockNpmregistryClient) GetPackageVersion(_ context.Context, name, _ str
 	return &packageVersion, nil
 }
 
+func (r *mockNpmregistryClient) GetPackageLatestVersion(_ context.Context, name string) (*npm.PackageVersion, error) {
+	var packageVersion npm.PackageVersion
+	err := json.Unmarshal(r.versionContent, &packageVersion)
+	if err != nil {
+		return nil, err
+	}
+	if packageVersion.Name != name {
+		return nil, fmt.Errorf("GetPackageVersion: name mismatch")
+	}
+
+	return &packageVersion, nil
+}
+
 func TestAnalysisRequestFromJSON(t *testing.T) {
 	type args struct {
 		body []byte

--- a/analysisrequest/npm.go
+++ b/analysisrequest/npm.go
@@ -153,6 +153,7 @@ func (arn *NPM) fillMissingData(parent context.Context, registryClient npm.Regis
 		}
 		arn.Version = pv.Version
 		arn.Shasum = pv.Dist.Shasum
+
 		return nil
 	}
 
@@ -166,6 +167,7 @@ func (arn *NPM) fillMissingData(parent context.Context, registryClient npm.Regis
 		}
 		arn.Version = pv.Version
 		arn.Shasum = pv.Dist.Shasum
+
 		return nil
 	}
 


### PR DESCRIPTION
There are certain npm packages, (e.g:
https://registry.npmjs.org/@typescript-eslint/eslint-plugin) that are extremely heavy in terms of number of versions and metadata in general.

NPM.fillMissingData was asking for the full list when called causing issues to the caller when the timeout is reached.

This fix makes fillMissingData call the specific routes for what it needs so we remove the number of versions from the equation.