### PR TITLE
feat: introduce MD{N,P}09 verdict code + make MD{N,P}{4,9} non-uniquely identifying verdict codes

### DIFF
--- a/verdictcode/code.gen.go
+++ b/verdictcode/code.gen.go
@@ -22,7 +22,9 @@ const (
 	MDN06  Code = 1026
 	MDN07  Code = 1027
 	MDN08  Code = 1028
+	MDN09  Code = 1029
 	MDP04  Code = 1324
+	MDP09  Code = 1329
 	RUN001 Code = 1200
 	STN001 Code = 1101
 	STN002 Code = 1102

--- a/verdictcode/code.yml
+++ b/verdictcode/code.yml
@@ -59,6 +59,7 @@ components:
         - 1026 # MDN06
         - 1027 # MDN07
         - 1028 # MDN08
+        - 1029 # MDN09
         - 1101 # STN001
         - 1102 # STN002
         - 1103 # STN003
@@ -70,6 +71,7 @@ components:
         - 1109 # STN009
         - 1200 # RUN001
         - 1324 # MDP04
+        - 1329 # MDP09
       x-enumNames:
         - "UNK"
         - "FNI001" # npm install spawn a child process
@@ -86,11 +88,12 @@ components:
         - "MDN01" # Empty description
         - "MDN02" # Zero version
         - "MDN03" # Prerelease version
-        - "MDN04" # Potentially compromised NPM maintainer's email domain
+        - "MDN04" # Potentially compromised NPM maintainer's email domain (re-registered domain)
         - "MDN05" # Mismatch between the NPM registry package name vs the tarball's package.json name
         - "MDN06" # Mismatch between the NPM registry package scripts vs the tarball's package.json scripts
         - "MDN07" # Mismatch between the NPM registry package dependencies vs the tarball's package.json dependencies
         - "MDN08" # Mismatch between the NPM registry package devDependencies vs the tarball's package.json devDependencies
+        - "MDN09" # Potentially compromised NPM maintainer's email domain (available domain)
         - "STN001" # Javascript env exfiltration
         - "STN002" # Javascript child process exec
         - "STN003" # Shady links
@@ -101,7 +104,8 @@ components:
         - "STN008" # npm github dependency
         - "STN009" # npm github gist dependency
         - "RUN001" # runtime (DNS)
-        - "MDP04"  # Potentially compromised PyPi maintainer's email domain
+        - "MDP04"  # Potentially compromised PyPi maintainer's email domain (re-registered domain)
+        - "MDP09"  # Potentially compromised NPM maintainer's email domain (available domain)
       x-oapi-codegen-extra-tags:
         validate: required_with=Message,isdefault|is_verdictcode
         human: the code identifying the verdict type

--- a/verdictcode/code_string.go
+++ b/verdictcode/code_string.go
@@ -25,7 +25,9 @@ func _() {
 	_ = x[MDN06-1026]
 	_ = x[MDN07-1027]
 	_ = x[MDN08-1028]
+	_ = x[MDN09-1029]
 	_ = x[MDP04-1324]
+	_ = x[MDP09-1329]
 	_ = x[RUN001-1200]
 	_ = x[STN001-1101]
 	_ = x[STN002-1102]
@@ -45,16 +47,17 @@ const (
 	_Code_name_0 = "UNKFNI001FNI002FNI003FNI004FNI005FNI006FNI007FNI008"
 	_Code_name_1 = "DDN01"
 	_Code_name_2 = "TSN01TSP01"
-	_Code_name_3 = "MDN01MDN02MDN03MDN04MDN05MDN06MDN07MDN08"
+	_Code_name_3 = "MDN01MDN02MDN03MDN04MDN05MDN06MDN07MDN08MDN09"
 	_Code_name_4 = "STN001STN002STN003STN004STN005STN006STN007STN008STN009"
 	_Code_name_5 = "RUN001"
 	_Code_name_6 = "MDP04"
+	_Code_name_7 = "MDP09"
 )
 
 var (
 	_Code_index_0 = [...]uint8{0, 3, 9, 15, 21, 27, 33, 39, 45, 51}
 	_Code_index_2 = [...]uint8{0, 5, 10}
-	_Code_index_3 = [...]uint8{0, 5, 10, 15, 20, 25, 30, 35, 40}
+	_Code_index_3 = [...]uint8{0, 5, 10, 15, 20, 25, 30, 35, 40, 45}
 	_Code_index_4 = [...]uint8{0, 6, 12, 18, 24, 30, 36, 42, 48, 54}
 )
 
@@ -67,7 +70,7 @@ func (i Code) String() string {
 	case 1011 <= i && i <= 1012:
 		i -= 1011
 		return _Code_name_2[_Code_index_2[i]:_Code_index_2[i+1]]
-	case 1021 <= i && i <= 1028:
+	case 1021 <= i && i <= 1029:
 		i -= 1021
 		return _Code_name_3[_Code_index_3[i]:_Code_index_3[i+1]]
 	case 1101 <= i && i <= 1109:
@@ -77,6 +80,8 @@ func (i Code) String() string {
 		return _Code_name_5
 	case i == 1324:
 		return _Code_name_6
+	case i == 1329:
+		return _Code_name_7
 	default:
 		return "Code(" + strconv.FormatInt(int64(i), 10) + ")"
 	}

--- a/verdictcode/mapping.go
+++ b/verdictcode/mapping.go
@@ -82,4 +82,8 @@ var nonUniquelyIdentifying = []Code{
 	FNI002,
 	FNI003,
 	RUN001,
+	MDN04,
+	MDN09,
+	MDP04,
+	MDP09,
 }


### PR DESCRIPTION
Their verdicts with `MDP04` or `MDP09` (same for `MDN04` and `MDN09` verdict codes) need the fingerprint for uniqueness.

Why?

Because for any package/version we may have more than on maintainer email with domain issues (re-registered, available domain).