### PR TITLE
feat(detection/type): introduce recipes

### DIFF
--- a/detection/type/detectiontype.gen.go
+++ b/detection/type/detectiontype.gen.go
@@ -5,22 +5,26 @@ package detectiontype
 
 // Defines values for Event.
 const (
+	BinaryExecutedByLoader        Event = 37
 	CapabilitiesModification      Event = 2
 	CodeModificationThroughProcfs Event = 21
-	CodeOnTheFlyAttempt           Event = 36
+	CodeOnTheFly                  Event = 36
 	ContainerEscapeAttempt        Event = 24
 	CorePatternAccess             Event = 12
 	CpuFingerprint                Event = 4
 	CredentialsFilesAccess        Event = 17
-	DenialOfServiceExec           Event = 31
+	DenialOfServiceTools          Event = 31
 	ExecFromUnusualDir            Event = 32
 	FileAttributeChange           Event = 33
 	FilesystemFingerprint         Event = 5
+	GlobalShlibModification       Event = 41
 	HiddenElfExec                 Event = 30
+	InterpreterShellSpawn         Event = 38
 	JavaDebugWireProtoLoad        Event = 11
 	JavaLibinstrumentLoad         Event = 10
 	MachineFingerprint            Event = 6
 	NetFilecopyToolExec           Event = 26
+	NetMitmToolExec               Event = 39
 	NetScanToolExec               Event = 27
 	NetSniffToolExec              Event = 28
 	NetSuspiciousToolExec         Event = 29
@@ -35,6 +39,7 @@ const (
 	ProcessCodeModification       Event = 22
 	ProcessFingerprint            Event = 8
 	ProcessMemoryAccess           Event = 23
+	RuncSuspiciousExec            Event = 40
 	SchedDebugAccess              Event = 13
 	ShellConfigModification       Event = 1
 	ShobjDeletedAfterLoad         Event = 9

--- a/detection/type/event_string.go
+++ b/detection/type/event_string.go
@@ -8,22 +8,26 @@ func _() {
 	// An "invalid array index" compiler error signifies that the constant values have changed.
 	// Re-run the stringer command to generate them again.
 	var x [1]struct{}
+	_ = x[BinaryExecutedByLoader-37]
 	_ = x[CapabilitiesModification-2]
 	_ = x[CodeModificationThroughProcfs-21]
-	_ = x[CodeOnTheFlyAttempt-36]
+	_ = x[CodeOnTheFly-36]
 	_ = x[ContainerEscapeAttempt-24]
 	_ = x[CorePatternAccess-12]
 	_ = x[CpuFingerprint-4]
 	_ = x[CredentialsFilesAccess-17]
-	_ = x[DenialOfServiceExec-31]
+	_ = x[DenialOfServiceTools-31]
 	_ = x[ExecFromUnusualDir-32]
 	_ = x[FileAttributeChange-33]
 	_ = x[FilesystemFingerprint-5]
+	_ = x[GlobalShlibModification-41]
 	_ = x[HiddenElfExec-30]
+	_ = x[InterpreterShellSpawn-38]
 	_ = x[JavaDebugWireProtoLoad-11]
 	_ = x[JavaLibinstrumentLoad-10]
 	_ = x[MachineFingerprint-6]
 	_ = x[NetFilecopyToolExec-26]
+	_ = x[NetMitmToolExec-39]
 	_ = x[NetScanToolExec-27]
 	_ = x[NetSniffToolExec-28]
 	_ = x[NetSuspiciousToolExec-29]
@@ -38,6 +42,7 @@ func _() {
 	_ = x[ProcessCodeModification-22]
 	_ = x[ProcessFingerprint-8]
 	_ = x[ProcessMemoryAccess-23]
+	_ = x[RuncSuspiciousExec-40]
 	_ = x[SchedDebugAccess-13]
 	_ = x[ShellConfigModification-1]
 	_ = x[ShobjDeletedAfterLoad-9]
@@ -47,9 +52,9 @@ func _() {
 	_ = x[UnprivilegedBpfConfigAccess-15]
 }
 
-const _Event_name = "NoneShellConfigModificationCapabilitiesModificationSudoersModificationCpuFingerprintFilesystemFingerprintMachineFingerprintOsFingerprintProcessFingerprintShobjDeletedAfterLoadJavaLibinstrumentLoadJavaDebugWireProtoLoadCorePatternAccessSchedDebugAccessSysrqAccessUnprivilegedBpfConfigAccessSslCertificateAccessCredentialsFilesAccessOsStatusFingerprintPamConfigModificationPackageRepoConfigModificationCodeModificationThroughProcfsProcessCodeModificationProcessMemoryAccessContainerEscapeAttemptOsNetworkFingerprintNetFilecopyToolExecNetScanToolExecNetSniffToolExecNetSuspiciousToolExecHiddenElfExecDenialOfServiceExecExecFromUnusualDirFileAttributeChangePasswdUsageNetSuspiciousToolShellCodeOnTheFlyAttempt"
+const _Event_name = "NoneShellConfigModificationCapabilitiesModificationSudoersModificationCpuFingerprintFilesystemFingerprintMachineFingerprintOsFingerprintProcessFingerprintShobjDeletedAfterLoadJavaLibinstrumentLoadJavaDebugWireProtoLoadCorePatternAccessSchedDebugAccessSysrqAccessUnprivilegedBpfConfigAccessSslCertificateAccessCredentialsFilesAccessOsStatusFingerprintPamConfigModificationPackageRepoConfigModificationCodeModificationThroughProcfsProcessCodeModificationProcessMemoryAccessContainerEscapeAttemptOsNetworkFingerprintNetFilecopyToolExecNetScanToolExecNetSniffToolExecNetSuspiciousToolExecHiddenElfExecDenialOfServiceToolsExecFromUnusualDirFileAttributeChangePasswdUsageNetSuspiciousToolShellCodeOnTheFlyBinaryExecutedByLoaderInterpreterShellSpawnNetMitmToolExecRuncSuspiciousExecGlobalShlibModification"
 
-var _Event_index = [...]uint16{0, 4, 27, 51, 70, 84, 105, 123, 136, 154, 175, 196, 218, 235, 251, 262, 289, 309, 331, 350, 371, 400, 429, 452, 471, 493, 513, 532, 547, 563, 584, 597, 616, 634, 653, 664, 686, 705}
+var _Event_index = [...]uint16{0, 4, 27, 51, 70, 84, 105, 123, 136, 154, 175, 196, 218, 235, 251, 262, 289, 309, 331, 350, 371, 400, 429, 452, 471, 493, 513, 532, 547, 563, 584, 597, 617, 635, 654, 665, 687, 699, 721, 742, 757, 775, 798}
 
 func (i Event) String() string {
 	if i >= Event(len(_Event_index)-1) {

--- a/detection/type/types.yml
+++ b/detection/type/types.yml
@@ -64,6 +64,11 @@ components:
         - 34
         - 35
         - 36
+        - 37
+        - 38
+        - 39
+        - 40
+        - 41
       x-enumNames:
         - "none"
         - "shell_config_modification"
@@ -96,9 +101,14 @@ components:
         - "net_sniff_tool_exec"
         - "net_suspicious_tool_exec"
         - "hidden_elf_exec"
-        - "denial_of_service_exec"
+        - "denial_of_service_tools"
         - "exec_from_unusual_dir"
         - "file_attribute_change"
         - "passwd_usage"
         - "net_suspicious_tool_shell"
-        - "code_on_the_fly_attempt"
+        - "code_on_the_fly"
+        - "binary_executed_by_loader"
+        - "interpreter_shell_spawn"
+        - "net_mitm_tool_exec"
+        - "runc_suspicious_exec"
+        - "global_shlib_modification"


### PR DESCRIPTION
Introduce the following detection recipes:

- binary_executed_by_loader
- interpreter_shell_spawn
- net_mitm_tool_exec
- runc_suspicious_exec
- global_shlib_modification

Rename these ones:

- denial_of_service_tools
- code_on_the_fly